### PR TITLE
Add Function to Import AprilTag Data from YAML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ pythonpath = ["."]    # Added to Python search path
 [tool.coverage.run]
 data_file = ".coverage/combined"
 branch = true                    # Measure branch coverage
-source = ["src", "tests"]        # Measure coverage over these source paths
+source = ["src"]                 # Measure coverage over these source paths
 
 [tool.coverage.report]
 show_missing = false # Do not list any lines missing coverage

--- a/src/transform_utils/filesystem/load_from_yaml.py
+++ b/src/transform_utils/filesystem/load_from_yaml.py
@@ -56,7 +56,7 @@ def load_named_poses_2d(landmarks_data: dict[str, Any], default_frame: str) -> d
 
 
 def load_named_poses(poses_data: dict[str, Any], default_frame: str) -> dict[str, Pose3D]:
-    """Load a collection of named 3D poses from data imported from YAML.
+    """Load a set of named 3D poses from data imported from YAML.
 
     :param poses_data: Dictionary mapping robot/object/location names to 3D pose data
     :param default_frame: Reference frame used for any poses without a specified frame
@@ -73,3 +73,26 @@ def load_named_poses(poses_data: dict[str, Any], default_frame: str) -> dict[str
             named_poses[name] = Pose3D.from_list(pose_list, ref_frame=ref_frame)
 
     return named_poses
+
+
+def load_apriltag_relative_transforms_from_yaml(yaml_path: Path) -> dict[str, Pose3D]:
+    """Load a set of AprilTag-to-object relative transforms from YAML.
+
+    :param yaml_path: Path to a YAML file specifying the relative transforms
+    :return: Map from object name to the relevant AprilTag-relative parent transform
+    """
+    yaml_data = load_yaml_into_dict(yaml_path)
+    assert "transforms" in yaml_data, f"Expected a top-level 'transforms' key in file {yaml_data}"
+
+    transforms_dict = {}
+
+    for tag_name, tag_data in yaml_data["transforms"].items():
+        assert "object" in tag_data, f"Missing 'object' key under tag {tag_name}."
+        assert "relative_pose" in tag_data, f"Missing 'relative_pose' key under tag {tag_name}."
+        object_name = tag_data["object"]
+
+        # Convert the YAML data into the object's AprilTag-relative pose
+        relative_pose = Pose3D.from_list(tag_data["relative_pose"], ref_frame=tag_name)
+        transforms_dict[object_name] = relative_pose
+
+    return transforms_dict

--- a/tests/data/apriltag_transforms_example.yaml
+++ b/tests/data/apriltag_transforms_example.yaml
@@ -1,0 +1,9 @@
+# Specify AprilTag-object relative transforms to be used in pose estimation
+transforms:
+  tag-39:
+    object: "expo_spray"
+    relative_pose: [1, 2, 3, 0, 0, 0] # Object's pose w.r.t. the AprilTag
+
+  tag-41:
+    object: "table1"
+    relative_pose: [4, 5, 6, 0, 0, 0]

--- a/tests/test_load_from_yaml.py
+++ b/tests/test_load_from_yaml.py
@@ -3,7 +3,12 @@
 import tempfile
 from pathlib import Path
 
-from transform_utils.filesystem.load_from_yaml import load_yaml_into_dict
+import pytest
+
+from transform_utils.filesystem.load_from_yaml import (
+    load_apriltag_relative_transforms_from_yaml,
+    load_yaml_into_dict,
+)
 
 
 def test_load_yaml_into_dict_file_not_found() -> None:
@@ -17,3 +22,36 @@ def test_load_yaml_into_dict_file_not_found() -> None:
 
         # Assert: The result should be an empty dictionary
         assert result == {}
+
+
+@pytest.fixture
+def apriltag_yaml_path() -> Path:
+    """Return the path to a known-good YAML file of AprilTag data stored under `tests/data`."""
+    yaml_path = Path(__file__).parent / "data" / "apriltag_transforms_example.yaml"
+    assert yaml_path.exists()
+    return yaml_path
+
+
+def test_load_apriltag_relative_transforms(apriltag_yaml_path: Path) -> None:
+    """Verify that AprilTag-relative object transforms can be imported from YAML."""
+    # Arrange: The YAML file path is provided via Pytest fixture
+
+    # Act: Import the AprilTag data from the example YAML file
+    transforms_result = load_apriltag_relative_transforms_from_yaml(apriltag_yaml_path)
+
+    # Assert: Verify that the loaded relative transforms match the expected values
+    expo_spray_pose = transforms_result.get("expo_spray")
+    table_pose = transforms_result.get("table1")
+
+    assert expo_spray_pose is not None, "Expected a relative pose for 'expo_spray'."
+    assert table_pose is not None, "Expected a relative pose for 'table1'."
+
+    assert expo_spray_pose.ref_frame == "tag-39"
+    assert expo_spray_pose.position.x == 1
+    assert expo_spray_pose.position.y == 2
+    assert expo_spray_pose.position.z == 3
+
+    assert table_pose.ref_frame == "tag-41"
+    assert table_pose.position.x == 4
+    assert table_pose.position.y == 5
+    assert table_pose.position.z == 6


### PR DESCRIPTION
This branch adds a function to `load_from_yaml.py` that loads AprilTag-relative object poses from YAML.