### PR TITLE
Add AprilTag Dataclass

### DIFF
--- a/src/transform_utils/filesystem/load_from_yaml.py
+++ b/src/transform_utils/filesystem/load_from_yaml.py
@@ -8,6 +8,7 @@ import yaml
 
 from transform_utils.kinematics import Pose2D, Pose3D
 from transform_utils.logging import log_error, log_info
+from transform_utils.world_model.april_tag import AprilTag
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -82,7 +83,7 @@ def load_apriltag_relative_transforms_from_yaml(yaml_path: Path) -> dict[str, Po
     :return: Map from object name to the relevant AprilTag-relative parent transform
     """
     yaml_data = load_yaml_into_dict(yaml_path)
-    assert "transforms" in yaml_data, f"Expected a top-level 'transforms' key in file {yaml_data}"
+    assert "transforms" in yaml_data, f"Expected a top-level 'transforms' key in file {yaml_data}."
 
     transforms_dict = {}
 

--- a/src/transform_utils/world_model/april_tag.py
+++ b/src/transform_utils/world_model/april_tag.py
@@ -1,0 +1,16 @@
+"""Define a dataclass to represent an AprilTag (i.e., an AR marker or visual fiducial)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from transform_utils.kinematics import Pose3D
+
+
+@dataclass
+class AprilTag:
+    """An AR marker at some pose in the world."""
+
+    id: int  # Unique ID of the tag
+    size_cm: float  # Size (in centimeters) of one side of the tag's black square
+    pose: Pose3D | None  # Estimated pose of the AprilTag (None if unknown)

--- a/src/transform_utils/world_model/tag_tracker.py
+++ b/src/transform_utils/world_model/tag_tracker.py
@@ -1,0 +1,34 @@
+"""Define a class to manage the tracking of detected AprilTag poses and dependent objects."""
+
+from pathlib import Path
+
+from transform_utils.filesystem.load_from_yaml import load_apriltag_relative_transforms_from_yaml
+
+
+class TagTracker:
+    """A class that stores and re-publishes the poses of detected AR tags."""
+
+    def __init__(self, tags_yaml: Path) -> None:
+        """Initialize the TagTracker by populating its list of known AprilTags.
+
+        :param tags_yaml: Path to a YAML file specifying AprilTag IDs and sizes
+        """
+
+
+#     def __init__(self) -> None:
+#         """Initialize the TagTracker by retrieving expected tag sizes from ROS parameters."""
+#         self.tag_poses: dict[int, Pose3D] = {}
+
+#         self._body_cam_marker_size_cm = rospy.get_param("/spot/ar/body_cam_marker_size_cm")
+#         self._hand_cam_marker_size_cm = rospy.get_param("/spot/ar/hand_cam_marker_size_cm")
+
+#     def marker_callback(self, markers_msg: AlvarMarkers) -> None:
+#         """Store updated tag poses from detected AR markers.
+
+#         :param markers_msg: Message containing a list of tag detections
+#         """
+#         for marker in markers_msg.markers:
+#             rospy.loginfo(f"Detected Marker ID: {marker.id} with confidence {marker.confidence}.")
+#             self.tag_poses[marker.id] = pose_from_msg(marker.pose)
+
+#         # TODO: Filter which poses are trusted based on the actual tag size and camera name

--- a/tests/data/apriltags_example.yaml
+++ b/tests/data/apriltags_example.yaml
@@ -1,9 +1,11 @@
 # Specify AprilTag-object relative transforms to be used in pose estimation
 transforms:
   tag-39:
+    tag_size_cm: 4.0 # Size (cm) of the tag along one side of its black square
     object: "expo_spray"
     relative_pose: [1, 2, 3, 0, 0, 0] # Object's pose w.r.t. the AprilTag
 
   tag-41:
+    tag_size_cm: 10.1
     object: "table1"
     relative_pose: [4, 5, 6, 0, 0, 0]


### PR DESCRIPTION
This branch introduces an `AprilTag` dataclass to manage the tag size of the AR markers. We need to track this explicitly because different cameras will be looking for different sizes of tags, so we should ignore estimates from a camera for any tags of the wrong size.