### PR TITLE
Add AprilTag Dataclass

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,33 @@
+{
+    "editor.minimap.enabled": true,
+    "editor.rulers": [
+        80,
+        100
+    ],
+    "editor.insertSpaces": true,
+    "editor.tabSize": 4,
+    "editor.stickyTabStops": true,
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "[json]": {
+        "editor.defaultFormatter": "vscode.json-language-features"
+    },
+    "[jsonc]": {
+        "editor.defaultFormatter": "vscode.json-language-features"
+    },
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
+        }
+    },
+    "autoDocstring.docstringFormat": "sphinx-notypes",
+    "notebook.codeActionsOnSave": {
+        "notebook.source.fixAll": "explicit",
+        "notebook.source.organizeImports": "explicit"
+    },
+    "[toml]": {
+        "editor.defaultFormatter": "tamasfe.even-better-toml"
+    }
+}

--- a/src/transform_utils/filesystem/load_from_yaml.py
+++ b/src/transform_utils/filesystem/load_from_yaml.py
@@ -8,6 +8,7 @@ import yaml
 
 from transform_utils.kinematics import Pose2D, Pose3D
 from transform_utils.logging import log_error, log_info
+from transform_utils.world_model.april_tag import AprilTag
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -82,7 +83,7 @@ def load_apriltag_relative_transforms_from_yaml(yaml_path: Path) -> dict[str, Po
     :return: Map from object name to the relevant AprilTag-relative parent transform
     """
     yaml_data = load_yaml_into_dict(yaml_path)
-    assert "transforms" in yaml_data, f"Expected a top-level 'transforms' key in file {yaml_data}"
+    assert "transforms" in yaml_data, f"Expected a top-level 'transforms' key in file {yaml_data}."
 
     transforms_dict = {}
 

--- a/src/transform_utils/filesystem/load_from_yaml.py
+++ b/src/transform_utils/filesystem/load_from_yaml.py
@@ -8,7 +8,6 @@ import yaml
 
 from transform_utils.kinematics import Pose2D, Pose3D
 from transform_utils.logging import log_error, log_info
-from transform_utils.world_model.april_tag import AprilTag
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -74,26 +73,3 @@ def load_named_poses(poses_data: dict[str, Any], default_frame: str) -> dict[str
             named_poses[name] = Pose3D.from_list(pose_list, ref_frame=ref_frame)
 
     return named_poses
-
-
-def load_apriltag_relative_transforms_from_yaml(yaml_path: Path) -> dict[str, Pose3D]:
-    """Load a set of AprilTag-to-object relative transforms from YAML.
-
-    :param yaml_path: Path to a YAML file specifying the relative transforms
-    :return: Map from object name to the relevant AprilTag-relative parent transform
-    """
-    yaml_data = load_yaml_into_dict(yaml_path)
-    assert "transforms" in yaml_data, f"Expected a top-level 'transforms' key in file {yaml_data}."
-
-    transforms_dict = {}
-
-    for tag_name, tag_data in yaml_data["transforms"].items():
-        assert "object" in tag_data, f"Missing 'object' key under tag {tag_name}."
-        assert "relative_pose" in tag_data, f"Missing 'relative_pose' key under tag {tag_name}."
-        object_name = tag_data["object"]
-
-        # Convert the YAML data into the object's AprilTag-relative pose
-        relative_pose = Pose3D.from_list(tag_data["relative_pose"], ref_frame=tag_name)
-        transforms_dict[object_name] = relative_pose
-
-    return transforms_dict

--- a/src/transform_utils/kinematics.py
+++ b/src/transform_utils/kinematics.py
@@ -273,7 +273,7 @@ class Pose3D:
     @classmethod
     def from_yaml(cls, pose_data: list[float] | dict[str, Any], default_frame: str) -> Pose3D:
         """Construct a Pose3D instance from data imported from YAML.
-        
+
         :param pose_data: List or dictionary of YAML data representing a pose
         :param default_frame: Default reference frame to use if the YAML doesn't specify one
         :return: Constructed Pose3D instance

--- a/src/transform_utils/kinematics.py
+++ b/src/transform_utils/kinematics.py
@@ -273,6 +273,7 @@ class Pose3D:
     @classmethod
     def from_yaml(cls, pose_data: list[float] | dict[str, Any], default_frame: str) -> Pose3D:
         """Construct a Pose3D instance from data imported from YAML.
+        
         :param pose_data: List or dictionary of YAML data representing a pose
         :param default_frame: Default reference frame to use if the YAML doesn't specify one
         :return: Constructed Pose3D instance

--- a/src/transform_utils/kinematics.py
+++ b/src/transform_utils/kinematics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Any, Dict
 
 import numpy as np
 from transforms3d.euler import euler2quat, quat2euler
@@ -269,6 +269,26 @@ class Pose3D:
         matrix[:3, :3] = self.orientation.to_rotation_matrix()
         matrix[:3, 3] = [self.position.x, self.position.y, self.position.z]
         return matrix
+
+    @classmethod
+    def from_yaml(cls, pose_data: list[float] | dict[str, Any], default_frame: str) -> Pose3D:
+        """Construct a Pose3D instance from data imported from YAML.
+        :param pose_data: List or dictionary of YAML data representing a pose
+        :param default_frame: Default reference frame to use if the YAML doesn't specify one
+        :return: Constructed Pose3D instance
+        :raises: TypeError if the pose data has an unexpected type
+        """
+        if isinstance(pose_data, list):  # Pose represented as XYZ-RPY list
+            ref_frame = default_frame
+            pose_list = pose_data
+        elif isinstance(pose_data, dict):  # Pose with reference frame specified
+            ref_frame = pose_data.get("frame", default_frame)
+            pose_list = pose_data["xyz_rpy"]
+        else:
+            error_msg = f"Pose3D.from_yaml() cannot process type {type(pose_data)}."
+            raise TypeError(error_msg)
+
+        return Pose3D.from_list(xyz_rpy=pose_list, ref_frame=ref_frame)
 
     def approx_equal(self, other: Pose3D) -> bool:
         """Check whether another Pose3D is approximately equal to this one."""

--- a/src/transform_utils/world_model/april_tag.py
+++ b/src/transform_utils/world_model/april_tag.py
@@ -52,7 +52,7 @@ class AprilTag:
 class AprilTagSystem:
     """A system of known AprilTags and tag-detecting cameras."""
 
-    tags: dict[int, AprilTag]  # Maps tag IDs to AprilTag instances
+    tags: dict[int, AprilTag]  # Map tag IDs to AprilTag instances
     camera_detects_tags: dict[str, set[int]]  # Map camera names to the tags they can detect
     camera_topic_prefix: str  # Prefix for AR marker detection ROS topics
 
@@ -69,8 +69,7 @@ class AprilTagSystem:
         topic_prefix = yaml_data.get("camera_topic_prefix", "")
         system = AprilTagSystem(tags={}, camera_detects_tags={}, camera_topic_prefix=topic_prefix)
 
-        tags_data = yaml_data["tags"]
-        for tag_name, tag_data in tags_data.items():
+        for tag_name, tag_data in yaml_data["tags"].items():
             new_tag = AprilTag.from_yaml(tag_name, tag_data)
             system.tags[new_tag.id] = new_tag
 

--- a/src/transform_utils/world_model/april_tag.py
+++ b/src/transform_utils/world_model/april_tag.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import isclose
+from pathlib import Path
+from typing import Any
 
+from transform_utils.filesystem.load_from_yaml import load_yaml_into_dict
 from transform_utils.kinematics import Pose3D
 
 
@@ -14,3 +18,67 @@ class AprilTag:
     id: int  # Unique ID of the tag
     size_cm: float  # Size (in centimeters) of one side of the tag's black square
     pose: Pose3D | None  # Estimated pose of the AprilTag (None if unknown)
+    relative_frames: dict[str, Pose3D]  # Object frames w.r.t. the AprilTag
+
+    @classmethod
+    def from_yaml(cls, tag_name: str, tag_data: dict[str, Any]) -> AprilTag:
+        """Construct an AprilTag instance from imported YAML data.
+
+        :param tag_name: Name of the tag (of the form "tag_XX")
+        :param tag_data: AprilTag data imported from YAML
+        :return: Constructed AprilTag instance
+        """
+        assert tag_name.startswith("tag_"), f"{tag_name} is not of the form 'tag_XX'."
+        assert "tag_size_cm" in tag_data, f"Expected tag {tag_name} to have key 'tag_size_cm'."
+
+        tag_id = int(tag_name[4:])
+        tag_size_cm = tag_data["tag_size_cm"]
+        output_tag = AprilTag(id=tag_id, size_cm=tag_size_cm, pose=None, relative_frames={})
+
+        frames = tag_data.get("relative_frames", {})  # Map from frame names to relative poses
+        for child_frame_name, pose_data in frames.items():
+            relative_pose = Pose3D.from_yaml(pose_data, default_frame=tag_name)
+            output_tag.relative_frames[child_frame_name] = relative_pose
+
+        return output_tag
+
+
+@dataclass
+class AprilTagSystem:
+    """A system of known AprilTags and tag-detecting cameras."""
+
+    tags: dict[int, AprilTag]  # Maps tag IDs to AprilTag instances
+    camera_detects_tags: dict[str, set[int]]  # Map camera names to the tags they can detect
+    camera_topic_prefix: str  # Prefix for AR marker detection ROS topics
+
+    @classmethod
+    def from_yaml(cls, yaml_path: Path) -> AprilTagSystem:
+        """Load a system of AprilTags and tag-detecting cameras from a YAML file.
+
+        :param yaml_path: Path to a YAML file specifying AprilTag and camera data
+        :return: Constructed AprilTagSystem instance
+        """
+        yaml_data = load_yaml_into_dict(yaml_path)
+        assert "tags" in yaml_data, f"Expected key 'tags' in YAML file {yaml_path}."
+
+        topic_prefix = yaml_data.get("camera_topic_prefix", "")
+        system = AprilTagSystem(tags={}, camera_detects_tags={}, camera_topic_prefix=topic_prefix)
+
+        tags_data = yaml_data["tags"]
+        for tag_name, tag_data in tags_data.items():
+            new_tag = AprilTag.from_yaml(tag_name, tag_data)
+            system.tags[new_tag.id] = new_tag
+
+        assert "cameras" in yaml_data, f"Expected key 'cameras' in YAML file {yaml_path}."
+        for camera_name, camera_data in yaml_data["cameras"].items():
+            system.camera_detects_tags[camera_name] = set()
+
+            # Check if each tag's size is approximately one that this camera recognizes
+            recognized_sizes_cm: set[float] = set(camera_data["recognized_tag_sizes_cm"])
+            for tag in system.tags.values():
+                for recognized_size_cm in recognized_sizes_cm:
+                    if isclose(tag.size_cm, recognized_size_cm):
+                        system.camera_detects_tags[camera_name].add(tag.id)
+                        break  # Move to the next AprilTag
+
+        return system

--- a/src/transform_utils/world_model/april_tag.py
+++ b/src/transform_utils/world_model/april_tag.py
@@ -42,6 +42,11 @@ class AprilTag:
 
         return output_tag
 
+    @property
+    def frame_name(self) -> str:
+        """Retrieve the name of the /tf frame defined by this AprilTag."""
+        return f"tag_{self.id}"
+
 
 @dataclass
 class AprilTagSystem:

--- a/src/transform_utils/world_model/april_tag.py
+++ b/src/transform_utils/world_model/april_tag.py
@@ -1,0 +1,16 @@
+"""Define a dataclass to represent an AprilTag (i.e., an AR marker or visual fiducial)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from transform_utils.kinematics import Pose3D
+
+
+@dataclass
+class AprilTag:
+    """An AR marker at some pose in the world."""
+
+    id: int  # Unique ID of the tag
+    size_cm: float  # Size (in centimeters) of one side of the tag's black square
+    pose: Pose3D | None  # Estimated pose of the AprilTag (None if unknown)

--- a/src/transform_utils/world_model/tag_tracker.py
+++ b/src/transform_utils/world_model/tag_tracker.py
@@ -68,7 +68,7 @@ class TagTracker:
 
             actual_tag = self.tag_system.tags[marker.id]
             if actual_tag.in_bundle != bundle:
-                continue  # Ensure that single-tag topics aren't applied to bundled markers
+                continue  # Ensure that single-tag detections aren't used for bundled markers
 
             rospy.loginfo(
                 f"Marker ID {marker.id} (size {actual_tag.size_cm} cm) was detected by camera "

--- a/src/transform_utils/world_model/tag_tracker.py
+++ b/src/transform_utils/world_model/tag_tracker.py
@@ -54,7 +54,7 @@ class TagTracker:
                         f"{self.tag_system.camera_topic_prefix}/{camera_name}/bundle",
                         AlvarMarkers,
                         callback=self.marker_callback,
-                        callback_args=(),
+                        callback_args=callback_args,
                         queue_size=5,
                     ),
                 )
@@ -74,7 +74,7 @@ class TagTracker:
             return
 
         for marker in markers_msg.markers:
-            if marker.id not in self.tag_system.camera_detects_tags[camera_name]:
+            if marker.id not in self.tag_system.camera_detects_tags[args.camera_name]:
                 continue  # Move to the next marker detection
 
             tag = self.tag_system.tags[marker.id]

--- a/src/transform_utils/world_model/tag_tracker.py
+++ b/src/transform_utils/world_model/tag_tracker.py
@@ -1,0 +1,34 @@
+"""Define a class to manage the tracking of detected AprilTag poses and dependent objects."""
+
+from pathlib import Path
+
+from transform_utils.filesystem.load_from_yaml import load_apriltag_relative_transforms_from_yaml
+
+
+class TagTracker:
+    """A class that stores and re-publishes the poses of detected AR tags."""
+
+    def __init__(self, tags_yaml: Path) -> None:
+        """Initialize the TagTracker by populating its list of known AprilTags.
+
+        :param tags_yaml: Path to a YAML file specifying AprilTag IDs and sizes
+        """
+
+
+#     def __init__(self) -> None:
+#         """Initialize the TagTracker by retrieving expected tag sizes from ROS parameters."""
+#         self.tag_poses: dict[int, Pose3D] = {}
+
+#         self._body_cam_marker_size_cm = rospy.get_param("/spot/ar/body_cam_marker_size_cm")
+#         self._hand_cam_marker_size_cm = rospy.get_param("/spot/ar/hand_cam_marker_size_cm")
+
+#     def marker_callback(self, markers_msg: AlvarMarkers) -> None:
+#         """Store updated tag poses from detected AR markers.
+
+#         :param markers_msg: Message containing a list of tag detections
+#         """
+#         for marker in markers_msg.markers:
+#             rospy.loginfo(f"Detected Marker ID: {marker.id} with confidence {marker.confidence}.")
+#             self.tag_poses[marker.id] = pose_from_msg(marker.pose)
+
+#         # TODO: Filter which poses are trusted based on the actual tag size and camera name

--- a/src/transform_utils/world_model/tag_tracker.py
+++ b/src/transform_utils/world_model/tag_tracker.py
@@ -23,39 +23,55 @@ class TagTracker:
         self.marker_subs: list[rospy.Subscriber] = []
 
         # Populate the ROS subscribers based on the imported tags and camera names
-        for camera_name in self.tag_system.camera_detects_tags:
-            self.marker_subs.append(
-                rospy.Subscriber(
-                    f"{self.tag_system.camera_topic_prefix}{camera_name}",
-                    AlvarMarkers,
-                    callback=self.marker_callback,
-                    callback_args=camera_name,
-                    queue_size=5,
-                ),
-            )
+        for camera_name, camera in self.tag_system.cameras.items():
+            if camera.detects_single_tags:
+                topic_name = f"{self.tag_system.camera_topic_prefix}/{camera_name}/single"
+                self.marker_subs.append(
+                    rospy.Subscriber(
+                        topic_name,
+                        AlvarMarkers,
+                        callback=self.marker_callback,
+                        callback_args=topic_name,
+                        queue_size=5,
+                    ),
+                )
+
+            if camera.detects_bundles:
+                topic_name = f"{self.tag_system.camera_topic_prefix}/{camera_name}/bundle"
+                self.marker_subs.append(
+                    rospy.Subscriber(
+                        topic_name,
+                        AlvarMarkers,
+                        callback=self.marker_callback,
+                        callback_args=topic_name,
+                        queue_size=5,
+                    ),
+                )
 
         self._tf_publisher_thread = threading.Thread(target=self._publish_frames_loop)
         self._tf_publisher_thread.daemon = True  # Thread exits when main process does
         self._tf_publisher_thread.start()
 
-    def marker_callback(self, markers_msg: AlvarMarkers, camera_name: str) -> None:
+    def marker_callback(self, markers_msg: AlvarMarkers, camera_name: str, bundle: bool) -> None:
         """Handle new AR marker detections from the named camera.
 
         :param markers_msg: Message containing a list of tag detections
         :param camera_name: Name of the camera source of the detections
+        :param bundle: Whether this topic corresponds to bundled markers
         """
-        assert camera_name in self.tag_system.camera_detects_tags, (
-            f"Unrecognized camera name: {camera_name}."
-        )
+        if camera_name not in self.tag_system.cameras:
+            rospy.logwarn(f"Unrecognized camera name: {camera_name}.")
 
         for marker in markers_msg.markers:
             if marker.id not in self.tag_system.camera_detects_tags[camera_name]:
                 continue  # Move to the next marker detection
 
-            tag_size_cm = self.tag_system.tags[marker.id].size_cm
+            actual_tag = self.tag_system.tags[marker.id]
+            if actual_tag.in_bundle != bundle:
+                continue  # Ensure that single-tag topics aren't applied to bundled markers
 
             rospy.loginfo(
-                f"Marker ID {marker.id} (size {tag_size_cm} cm) was detected by camera "
+                f"Marker ID {marker.id} (size {actual_tag.size_cm} cm) was detected by camera "
                 f"'{camera_name}' with confidence {marker.confidence}.",
             )
 

--- a/tests/data/apriltags_example.yaml
+++ b/tests/data/apriltags_example.yaml
@@ -1,9 +1,11 @@
 # Specify AprilTag-object relative transforms to be used in pose estimation
 transforms:
   tag-39:
+    tag_size_cm: 4.0 # Size (cm) of the tag along one side of its black square
     object: "expo_spray"
     relative_pose: [1, 2, 3, 0, 0, 0] # Object's pose w.r.t. the AprilTag
 
   tag-41:
+    tag_size_cm: 10.1
     object: "table1"
     relative_pose: [4, 5, 6, 0, 0, 0]

--- a/tests/data/apriltags_example.yaml
+++ b/tests/data/apriltags_example.yaml
@@ -1,11 +1,24 @@
-# Specify AprilTag-object relative transforms to be used in pose estimation
-transforms:
-  tag-39:
-    tag_size_cm: 4.0 # Size (cm) of the tag along one side of its black square
-    object: "expo_spray"
-    relative_pose: [1, 2, 3, 0, 0, 0] # Object's pose w.r.t. the AprilTag
+# Specify AprilTag-object relative transforms, tag sizes, and which cameras detect which tag sizes
+tags:
+  tag_1:
+    tag_size_cm: 3.3 # Size (cm) of the tag along one side of its black square
+    relative_frames:
+      expo_spray: [1, 2, 3, 0, 0, 0] # Object's pose w.r.t. the AprilTag
 
-  tag-41:
-    tag_size_cm: 10.1
-    object: "table1"
-    relative_pose: [4, 5, 6, 0, 0, 0]
+  tag_101:
+    tag_size_cm: 4.4
+    relative_frames:
+      table: [4, 5, 6, 0, 0, 0]
+
+# Each camera can detect tags of one or more specific sizes
+cameras:
+  hand:
+    recognized_tag_sizes_cm: [3.3]
+
+  frontleft:
+    recognized_tag_sizes_cm: [4.4]
+
+  right:
+    recognized_tag_sizes_cm: [3.3, 4.4]
+
+camera_topic_prefix: "/ar_track_alvar/camera/"

--- a/tests/data/apriltags_example.yaml
+++ b/tests/data/apriltags_example.yaml
@@ -1,24 +1,37 @@
-# Specify AprilTag-to-object relative transforms, tag sizes, and which cameras detect which tag sizes
+# Specify AprilTag-to-object relative transforms, tag sizes, which cameras detect which sizes, etc.
+# NOTE: This file is NOT meant for our ROS system. It's used to unit test the YAML import code
 tags:
-  tag_1:
-    tag_size_cm: 3.3 # Size (cm) of the tag along one side of its black square
+  tag_60:
+    tag_size_cm: 4.0 # Size (cm) of the tag along one side of its black square
     relative_frames:
-      expo_spray: [1, 2, 3, 0, 0, 0] # Object's pose w.r.t. the AprilTag
+      expo_spray: [0.1, 0, 0, 0, 0, 0] # Object pose w.r.t. the AprilTag
 
-  tag_101:
-    tag_size_cm: 4.4
+  tag_51:
+    tag_size_cm: 18.5
     relative_frames:
-      table: [4, 5, 6, 0, 0, 0]
+      table: [-0.1, 0, -0.5, 1.5708, 0, 0]
+
+  tag_1:
+    tag_size_cm: 7.62
+    relative_frames:
+      cabinet_handle: [0.32, 0.24, 0.18, 0, 0, 0]
+    bundle: True
 
 # Each camera can detect tags of one or more specific sizes
 cameras:
   hand:
-    recognized_tag_sizes_cm: [3.3]
+    recognized_tag_sizes_cm: [4.0, 7.62]
+    detects_single_tags: True
+    detects_bundles: True
 
   frontleft:
-    recognized_tag_sizes_cm: [4.4]
+    recognized_tag_sizes_cm: [7.62, 18.5]
+    detects_single_tags: True
+    detects_bundles: True
 
-  right:
-    recognized_tag_sizes_cm: [3.3, 4.4]
+  frontright:
+    recognized_tag_sizes_cm: [7.62, 18.5]
+    detects_single_tags: True
+    detects_bundles: True
 
-camera_topic_prefix: "/ar_track_alvar/camera/"
+camera_topic_prefix: "/ar_pose_marker"

--- a/tests/data/apriltags_example.yaml
+++ b/tests/data/apriltags_example.yaml
@@ -1,4 +1,4 @@
-# Specify AprilTag-object relative transforms, tag sizes, and which cameras detect which tag sizes
+# Specify AprilTag-to-object relative transforms, tag sizes, and which cameras detect which tag sizes
 tags:
   tag_1:
     tag_size_cm: 3.3 # Size (cm) of the tag along one side of its black square

--- a/tests/data/pose_examples.yaml
+++ b/tests/data/pose_examples.yaml
@@ -1,0 +1,9 @@
+# Example Pose3D instances specified via YAML
+
+poses:
+  pose_a: [3, 2, 1, 0, 0.7854, 0] # Pitch: 45 degrees
+  pose_b:
+    xyz_rpy: [0, 2, 1, 0, 0, 0]
+  pose_c:
+    xyz_rpy: [4, 5, 6, 0, 0, 0]
+    frame: "frame_c"

--- a/tests/test_april_tag.py
+++ b/tests/test_april_tag.py
@@ -1,0 +1,60 @@
+"""Define unit tests for the AprilTag and AprilTagSystem dataclasses."""
+
+from pathlib import Path
+
+import pytest
+
+from transform_utils.kinematics import Pose3D
+from transform_utils.world_model.april_tag import AprilTagSystem
+
+
+@pytest.fixture
+def apriltag_yaml_path() -> Path:
+    """Return the path to a known-good YAML file of AprilTag data stored under `tests/data`."""
+    yaml_path = Path(__file__).parent / "data" / "apriltags_example.yaml"
+    assert yaml_path.exists()
+    return yaml_path
+
+
+def test_april_tag_system_from_yaml(apriltag_yaml_path: Path) -> None:
+    """Verify that the AprilTagSystem class can be imported from YAML."""
+    # Arrange: The YAML file path is provided via Pytest fixture
+    expected_expo_spray_pose = Pose3D.from_list([1, 2, 3, 0, 0, 0], ref_frame="tag_1")
+    expected_table_pose = Pose3D.from_list([4, 5, 6, 0, 0, 0], ref_frame="tag_101")
+
+    # Act: Import the AprilTag system data from the example YAML file
+    system_result = AprilTagSystem.from_yaml(apriltag_yaml_path)
+
+    # Assert: Verify that the loaded AprilTags data matches the expected values
+    tag_1 = system_result.tags.get(1)
+    tag_101 = system_result.tags.get(101)
+
+    assert tag_1 is not None, "Expected an AprilTag with the ID 1."
+    assert tag_101 is not None, "Expected an AprilTag with the ID 101."
+
+    assert tag_1.size_cm == pytest.approx(3.3)
+    assert "expo_spray" in tag_1.relative_frames
+
+    result_expo_spray_pose = tag_1.relative_frames["expo_spray"]
+    assert result_expo_spray_pose.approx_equal(expected_expo_spray_pose)
+
+    assert tag_101.size_cm == pytest.approx(4.4)
+    assert "table" in tag_101.relative_frames
+
+    result_table_pose = tag_101.relative_frames["table"]
+    assert result_table_pose.approx_equal(expected_table_pose)
+
+    # Verify that the imported cameras can detect the correct AprilTag IDs
+    hand_detects = system_result.camera_detects_tags.get("hand")
+    frontleft_detects = system_result.camera_detects_tags.get("frontleft")
+    right_detects = system_result.camera_detects_tags.get("right")
+
+    assert hand_detects is not None, "Expected a camera named 'hand'."
+    assert frontleft_detects is not None, "Expected a camera named 'frontleft'."
+    assert right_detects is not None, "Expected a camera named 'right'."
+
+    assert hand_detects == {1}
+    assert frontleft_detects == {101}
+    assert right_detects == {1, 101}
+
+    assert system_result.camera_topic_prefix == "/ar_track_alvar/camera/"

--- a/tests/test_april_tag.py
+++ b/tests/test_april_tag.py
@@ -19,42 +19,54 @@ def apriltag_yaml_path() -> Path:
 def test_april_tag_system_from_yaml(apriltag_yaml_path: Path) -> None:
     """Verify that the AprilTagSystem class can be imported from YAML."""
     # Arrange: The YAML file path is provided via Pytest fixture
-    expected_expo_spray_pose = Pose3D.from_list([1, 2, 3, 0, 0, 0], ref_frame="tag_1")
-    expected_table_pose = Pose3D.from_list([4, 5, 6, 0, 0, 0], ref_frame="tag_101")
+    expected_expo_spray_pose = Pose3D.from_list([0.1, 0, 0, 0, 0, 0], ref_frame="tag_60")
+    expected_table_pose = Pose3D.from_list([-0.1, 0, -0.5, 1.5708, 0, 0], ref_frame="tag_51")
+    expected_cabinet_pose = Pose3D.from_list([0.32, 0.24, 0.18, 0, 0, 0], ref_frame="tag_1")
 
     # Act: Import the AprilTag system data from the example YAML file
     system_result = AprilTagSystem.from_yaml(apriltag_yaml_path)
 
     # Assert: Verify that the loaded AprilTags data matches the expected values
     tag_1 = system_result.tags.get(1)
-    tag_101 = system_result.tags.get(101)
+    tag_51 = system_result.tags.get(51)
+    tag_60 = system_result.tags.get(60)
 
     assert tag_1 is not None, "Expected an AprilTag with the ID 1."
-    assert tag_101 is not None, "Expected an AprilTag with the ID 101."
+    assert tag_51 is not None, "Expected an AprilTag with the ID 51."
+    assert tag_60 is not None, "Expected an AprilTag with the ID 60."
 
-    assert tag_1.size_cm == pytest.approx(3.3)
-    assert "expo_spray" in tag_1.relative_frames
+    assert tag_1.size_cm == pytest.approx(7.62)
+    assert "cabinet_handle" in tag_1.relative_frames
+    assert tag_1.in_bundle, "Expected tag 1 to be part of a bundle of tags."
 
-    result_expo_spray_pose = tag_1.relative_frames["expo_spray"]
-    assert result_expo_spray_pose.approx_equal(expected_expo_spray_pose)
+    result_cabinet_pose = tag_1.relative_frames["cabinet_handle"]
+    assert result_cabinet_pose.approx_equal(expected_cabinet_pose)
 
-    assert tag_101.size_cm == pytest.approx(4.4)
-    assert "table" in tag_101.relative_frames
+    assert tag_51.size_cm == pytest.approx(18.5)
+    assert "table" in tag_51.relative_frames
+    assert not tag_51.in_bundle, "Expected tag 51 to be a single tag."
 
-    result_table_pose = tag_101.relative_frames["table"]
+    result_table_pose = tag_51.relative_frames["table"]
     assert result_table_pose.approx_equal(expected_table_pose)
+
+    assert tag_60.size_cm == pytest.approx(4.0)
+    assert "expo_spray" in tag_60.relative_frames
+    assert not tag_60.in_bundle, "Expected tag 60 to be a single tag."
+
+    result_expo_spray_pose = tag_60.relative_frames["expo_spray"]
+    assert result_expo_spray_pose.approx_equal(expected_expo_spray_pose)
 
     # Verify that the imported cameras can detect the correct AprilTag IDs
     hand_detects = system_result.camera_detects_tags.get("hand")
     frontleft_detects = system_result.camera_detects_tags.get("frontleft")
-    right_detects = system_result.camera_detects_tags.get("right")
+    frontright_detects = system_result.camera_detects_tags.get("frontright")
 
     assert hand_detects is not None, "Expected a camera named 'hand'."
     assert frontleft_detects is not None, "Expected a camera named 'frontleft'."
-    assert right_detects is not None, "Expected a camera named 'right'."
+    assert frontright_detects is not None, "Expected a camera named 'frontright'."
 
-    assert hand_detects == {1}
-    assert frontleft_detects == {101}
-    assert right_detects == {1, 101}
+    assert hand_detects == {1, 60}
+    assert frontleft_detects == {1, 51}
+    assert frontright_detects == {1, 51}
 
-    assert system_result.camera_topic_prefix == "/ar_track_alvar/camera/"
+    assert system_result.camera_topic_prefix == "/ar_pose_marker"

--- a/tests/test_load_from_yaml.py
+++ b/tests/test_load_from_yaml.py
@@ -5,10 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from transform_utils.filesystem.load_from_yaml import (
-    load_apriltag_relative_transforms_from_yaml,
-    load_yaml_into_dict,
-)
+from transform_utils.filesystem.load_from_yaml import load_yaml_into_dict
 
 
 def test_load_yaml_into_dict_file_not_found() -> None:
@@ -22,36 +19,3 @@ def test_load_yaml_into_dict_file_not_found() -> None:
 
         # Assert: The result should be an empty dictionary
         assert result == {}
-
-
-@pytest.fixture
-def apriltag_yaml_path() -> Path:
-    """Return the path to a known-good YAML file of AprilTag data stored under `tests/data`."""
-    yaml_path = Path(__file__).parent / "data" / "apriltag_transforms_example.yaml"
-    assert yaml_path.exists()
-    return yaml_path
-
-
-def test_load_apriltag_relative_transforms(apriltag_yaml_path: Path) -> None:
-    """Verify that AprilTag-relative object transforms can be imported from YAML."""
-    # Arrange: The YAML file path is provided via Pytest fixture
-
-    # Act: Import the AprilTag data from the example YAML file
-    transforms_result = load_apriltag_relative_transforms_from_yaml(apriltag_yaml_path)
-
-    # Assert: Verify that the loaded relative transforms match the expected values
-    expo_spray_pose = transforms_result.get("expo_spray")
-    table_pose = transforms_result.get("table1")
-
-    assert expo_spray_pose is not None, "Expected a relative pose for 'expo_spray'."
-    assert table_pose is not None, "Expected a relative pose for 'table1'."
-
-    assert expo_spray_pose.ref_frame == "tag-39"
-    assert expo_spray_pose.position.x == 1
-    assert expo_spray_pose.position.y == 2
-    assert expo_spray_pose.position.z == 3
-
-    assert table_pose.ref_frame == "tag-41"
-    assert table_pose.position.x == 4
-    assert table_pose.position.y == 5
-    assert table_pose.position.z == 6

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -40,7 +40,7 @@ def test_pose3d_from_yaml(poses_yaml_data: dict[str, Any]) -> None:
     # Act: Convert each pose from YAML data into a Pose3D instance
     loaded_poses: dict[str, Pose3D] = {}
     for pose_name, pose_data in poses_yaml_data.items():
-        loaded_poses[pose_name] = Pose3D.from_yaml(pose_data)
+        loaded_poses[pose_name] = Pose3D.from_yaml(pose_data, default_frame=DEFAULT_FRAME)
 
     # Assert: Verify that the loaded Pose3D instances match the expected values
     for pose_name, expected_pose in expected_poses.items():

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -1,0 +1,51 @@
+"""Define unit tests for the Pose3D class."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from transform_utils.filesystem.load_from_yaml import load_yaml_into_dict
+from transform_utils.kinematics import DEFAULT_FRAME, Pose3D
+
+
+@pytest.fixture
+def poses_yaml_data() -> dict[str, Any]:
+    """Return pose data imported from a known-good YAML file stored under `tests/data`."""
+    yaml_path = Path(__file__).parent / "data" / "pose_examples.yaml"
+    assert yaml_path.exists(), f"Cannot find the YAML file: {yaml_path}"
+
+    yaml_data: dict[str, Any] = load_yaml_into_dict(yaml_path)
+    assert "poses" in yaml_data, f"Expected key 'poses' in YAML file: {yaml_path}."
+
+    poses_data: dict[str, Any] = yaml_data["poses"]
+    return poses_data
+
+
+def test_pose3d_from_yaml(poses_yaml_data: dict[str, Any]) -> None:
+    """Verify that Pose3D instances can be imported from a known-good example YAML file."""
+    # Arrange: The YAML data is provided via Pytest fixture
+    expected_pose_a = Pose3D.from_list([3, 2, 1, 0, 0.7854, 0], ref_frame=DEFAULT_FRAME)
+    expected_pose_b = Pose3D.from_list([0, 2, 1, 0, 0, 0], ref_frame=DEFAULT_FRAME)
+    expected_pose_c = Pose3D.from_list([4, 5, 6, 0, 0, 0], ref_frame="frame_c")
+
+    expected_poses: dict[str, Pose3D] = {
+        "pose_a": expected_pose_a,
+        "pose_b": expected_pose_b,
+        "pose_c": expected_pose_c,
+    }
+
+    # Act: Convert each pose from YAML data into a Pose3D instance
+    loaded_poses: dict[str, Pose3D] = {}
+    for pose_name, pose_data in poses_yaml_data.items():
+        loaded_poses[pose_name] = Pose3D.from_yaml(pose_data)
+
+    # Assert: Verify that the loaded Pose3D instances match the expected values
+    for pose_name, expected_pose in expected_poses.items():
+        result_pose = loaded_poses.get(pose_name)
+        assert result_pose is not None, f"Expected a pose named '{pose_name}'."
+
+        assert result_pose.approx_equal(expected_pose)
+        assert result_pose.ref_frame == expected_pose.ref_frame


### PR DESCRIPTION
This branch introduces an AprilTag dataclass to manage the tag size of the AR markers. We need to track this explicitly because different cameras will be looking for different sizes of tags, so we should ignore estimates from a camera for any tags of the wrong size.